### PR TITLE
Prevent crash on class- or module-level exceptions

### DIFF
--- a/HTMLTestRunner.py
+++ b/HTMLTestRunner.py
@@ -65,11 +65,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # URL: http://tungwaiyip.info/software/HTMLTestRunner.html
 
 __author__ = "Wai Yip Tung"
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 
 """
 Change History
+
+Version 0.8.3
+* Prevent crash on class or module-level exceptions (Darren Wurf).
 
 Version 0.8.2
 * Show output inline instead of popup window (Viorel Lupu).
@@ -516,6 +519,7 @@ class _TestResult(TestResult):
 
     def __init__(self, verbosity=1):
         TestResult.__init__(self)
+        self.outputBuffer = StringIO.StringIO()
         self.stdout0 = None
         self.stderr0 = None
         self.success_count = 0
@@ -536,7 +540,6 @@ class _TestResult(TestResult):
     def startTest(self, test):
         TestResult.startTest(self, test)
         # just one buffer for both stdout and stderr
-        self.outputBuffer = StringIO.StringIO()
         stdout_redirector.fp = self.outputBuffer
         stderr_redirector.fp = self.outputBuffer
         self.stdout0 = sys.stdout


### PR DESCRIPTION
Hi,

This patch fixes a crash in HTMLTestRunner when a class-level or module-level exception is thrown. Below is a test case demonstrating the crash:

```
import sys
sys.path.append('.') # Location of HTMLTestRunner

import unittest
import HTMLTestRunner

def setUpModule():
        # This causes HTMLTestRunner to fail
        raise Exception('Module-level exception')

class HTMLTestCase(unittest.TestCase):
    @classmethod
    def setUpClass(cls):
        # This causes HTMLTestRunner to fail
        raise Exception('Class-level exception')

    def test_true(self):
        "Verifies that the value of True hasn't changed"
        self.assertTrue(True)

if __name__ == '__main__':
    case = unittest.TestLoader().loadTestsFromTestCase(HTMLTestCase)
    HTMLTestRunner.HTMLTestRunner().run(case)
```
