### PR TITLE
Fixed display garbled characters in test report issue

### DIFF
--- a/HTMLTestRunner.py
+++ b/HTMLTestRunner.py
@@ -774,13 +774,13 @@ class HTMLTestRunner(Template_mixin):
         if isinstance(o,str):
             # TODO: some problem with 'string_escape': it escape \n and mess up formating
             # uo = unicode(o.encode('string_escape'))
-            uo = o.decode('latin-1')
+            uo = o.decode('utf-8')
         else:
             uo = o
         if isinstance(e,str):
             # TODO: some problem with 'string_escape': it escape \n and mess up formating
             # ue = unicode(e.encode('string_escape'))
-            ue = e.decode('latin-1')
+            ue = e.decode('utf-8')
         else:
             ue = e
 

--- a/README
+++ b/README
@@ -4,5 +4,5 @@ BSD style license.
 
 Only a single file module HTMLTestRunner.py is needed to generate your report.
 
-Addtions:
+Additions:
 Change encoding type latin-1 to utf-8, When display garbled characters that include Chinese characters in test report.

--- a/README
+++ b/README
@@ -3,3 +3,6 @@ It generates easy to use HTML test reports. HTMLTestRunner is released under a
 BSD style license.
 
 Only a single file module HTMLTestRunner.py is needed to generate your report.
+
+Addtions:
+Change encoding type latin-1 to utf-8, When display garbled characters that include Chinese characters in test report.


### PR DESCRIPTION
Description:
When display garbled characters that include Chinese characters in test report,.
Solution:
Change encoding type latin-1 to utf-8.
