### PR TITLE
Update HTMLTestRunner.py

### DIFF
--- a/HTMLTestRunner.py
+++ b/HTMLTestRunner.py
@@ -527,7 +527,6 @@ class _TestResult(TestResult):
 
     def __init__(self, verbosity=1):
         TestResult.__init__(self)
-        self.outputBuffer = StringIO.StringIO()
         self.stdout0 = None
         self.stderr0 = None
         self.success_count = 0
@@ -548,6 +547,7 @@ class _TestResult(TestResult):
     def startTest(self, test):
         TestResult.startTest(self, test)
         # just one buffer for both stdout and stderr
+	self.outputBuffer = StringIO.StringIO()
         stdout_redirector.fp = self.outputBuffer
         stderr_redirector.fp = self.outputBuffer
         self.stdout0 = sys.stdout


### PR DESCRIPTION
self.outputBuffer = StringIO.StringIO() should use in the  _TestResult.starTtest  not in the _TestResult.__init__ which cause issue:"Detail output overlap #7"